### PR TITLE
Include provided MD5 checksums in the init message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ production.properties
 catalog
 mappings
 src/main/app/mule-app.properties
-src/test
 .DS_Store
 # Java defaults (https://github.com/github/gitignore/blob/master/Java.gitignore) #
 # --- #

--- a/src/main/app/kerf-initialize.xml
+++ b/src/main/app/kerf-initialize.xml
@@ -153,8 +153,13 @@ where filename = #[payload.filename]]]></db:parameterized-query>
         <set-variable variableName="older_than_1945" value="#[flowVars.dbResult.dc_rights_licenses == '&lt;dc_rights_licenses type=&#8221;list&#8221;&gt;&#8232; &lt;multiselect&gt;VIAA-ONDERWIJS&lt;/multiselect&gt;&#8232; &lt;multiselect&gt;VIAA-ONDERZOEK&lt;/multiselect&gt;&#8232; &lt;multiselect&gt;VIAA-INTRA_CP-CONTENT&lt;/multiselect&gt;&#8232; &lt;multiselect&gt;VIAA-INTRA_CP-METADATA-ALL&lt;/multiselect&gt;&#8232; &lt;multiselect&gt;VIAA-PUBLIEK-METADATA-ALL&lt;/multiselect&gt;&#8232; &lt;multiselect&gt;VIAA-PUBLIEK-CONTENT&lt;/multiselect&gt;&#8232; &lt;multiselect&gt;Publiek Domein&lt;/multiselect&gt;&#8232;&lt;/dc_rights_licences&gt;' ? true: false]" doc:name="Set older_than_1945"/>
         <set-payload value="#[flowVars.mets]" mimeType="application/xml" doc:name="Set Payload with mets"/>
         <dw:transform-message doc:name="Transform Message">
-            <dw:input-payload doc:sample="sample_data/empty.xml"/>
-            <dw:input-variable doc:sample="sample_data/MyPojo.dwl" variableName="directory"/>
+            <dw:input-payload doc:sample="sample_data/source_mets.xml"/>
+            <dw:input-variable doc:sample="sample_data/fVars_directory.dwl" variableName="directory"/>
+            <dw:input-variable doc:sample="sample_data/fVars_pid.dwl" variableName="pid"/>
+            <dw:input-variable doc:sample="sample_data/fVars_gazet.dwl" variableName="gazet"/>
+            <dw:input-variable doc:sample="sample_data/fVars_allFiles.dwl" variableName="allFiles"/>
+            <dw:input-variable doc:sample="sample_data/fVars_older_than_1945.dwl" variableName="older_than_1945"/>
+            
             <dw:set-payload><![CDATA[%dw 1.0
 %output application/json
 ---

--- a/src/main/app/kerf-initialize.xml
+++ b/src/main/app/kerf-initialize.xml
@@ -174,6 +174,9 @@ where filename = #[payload.filename]]]></db:parameterized-query>
 	    'video': 'TAPE-SHARE-EVENTS',
 	    'archive': 'TAPE-SHARE-EVENTS'
 	},
+	"checksums": {((flowVars.allFiles filter ($.md5 != null and $.md5 != "")) map using (filename = $.filename) {
+		'$filename': lower $.md5
+	})},
 	"agents": [
 		{
 			"roles": [ "ARCHIVIST" ],

--- a/src/test/resources/sample_data/fVars_allFiles.dwl
+++ b/src/test/resources/sample_data/fVars_allFiles.dwl
@@ -1,0 +1,47 @@
+%dw 1.0
+%output application/java
+---
+[
+  {
+    "id": "GRP_TIF_0001",
+    "md5": "55163305a1eaa23aeedb74a4baad7447",
+    "amdid": "AMD_TIF_0001",
+    "filename": "AVM_19441014_0001.tif"
+  },
+  {
+    "id": "GRP_TIF_0002",
+    "md5": "ef69185bbaaf2f443ac489630d06ec85",
+    "amdid": "AMD_TIF_0002",
+    "filename": "AVM_19441014_0002.tif"
+  },
+  {
+    "id": "GRP_JPG_0001",
+    "md5": null,
+    "amdid": null,
+    "filename": "AVM_19441014_0001.jpg"
+  },
+  {
+    "id": "GRP_JPG_0002",
+    "md5": null,
+    "amdid": null,
+    "filename": "AVM_19441014_0002.jpg"
+  },
+  {
+    "id": "GRP_ALTO_0001",
+    "md5": null,
+    "amdid": null,
+    "filename": "AVM_19441014_0001.xml"
+  },
+  {
+    "id": "GRP_ALTO_0002",
+    "md5": null,
+    "amdid": null,
+    "filename": "AVM_19441014_0002.xml"
+  },
+  {
+    "id": "GRP_CPDF_0001",
+    "md5": null,
+    "amdid": null,
+    "filename": "AVM_19441014.pdf"
+  }
+]

--- a/src/test/resources/sample_data/fVars_directory.dwl
+++ b/src/test/resources/sample_data/fVars_directory.dwl
@@ -1,0 +1,4 @@
+%dw 1.0
+%output application/java
+---
+"/export/home/OR-w66976m/incoming/kERF/kERF_002/AVM/1896/1205"

--- a/src/test/resources/sample_data/fVars_gazet.dwl
+++ b/src/test/resources/sample_data/fVars_gazet.dwl
@@ -1,0 +1,4 @@
+%dw 1.0
+%output application/java
+---
+"AVM_19441014"

--- a/src/test/resources/sample_data/fVars_older_than_1945.dwl
+++ b/src/test/resources/sample_data/fVars_older_than_1945.dwl
@@ -1,0 +1,4 @@
+%dw 1.0
+%output application/java
+---
+"false"

--- a/src/test/resources/sample_data/fVars_pid.dwl
+++ b/src/test/resources/sample_data/fVars_pid.dwl
@@ -1,0 +1,4 @@
+%dw 1.0
+%output application/java
+---
+"aaaaaaaaaa"

--- a/src/test/resources/sample_data/source_mets.xml
+++ b/src/test/resources/sample_data/source_mets.xml
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mets xmlns="http://www.loc.gov/METS/" xmlns:DC="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:QualifiedDC="http://purl.org/dc/elements/1.1/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <metsHdr CREATEDATE="2014-08-20T10:18:40">
+    <agent ROLE="DISSEMINATOR" ID="agent_1">
+      <name>some name</name>
+    </agent>
+    <agent ROLE="OTHER" ID="agent_2" OTHERROLE="Digitalisator">
+      <name>some digitalisator</name>
+    </agent>
+    <agent ROLE="ARCHIVIST" ID="agent_3">
+      <name>some archivist</name>
+    </agent>
+  </metsHdr>
+  <dmdSec ID="DC_METADATA">
+    <mdWrap MDTYPE="DC">
+      <xmlData>
+        <DC:dc>
+          <QualifiedDC:date>1944-10-14</QualifiedDC:date>
+          <QualifiedDC:identifier>Some identifier</QualifiedDC:identifier>
+          <QualifiedDC:language>dut</QualifiedDC:language>
+          <QualifiedDC:format>image/tiff</QualifiedDC:format>
+          <QualifiedDC:format>image/jpeg</QualifiedDC:format>
+          <QualifiedDC:format>text/xml</QualifiedDC:format>
+          <QualifiedDC:type xml:lang="dut">some type</QualifiedDC:type>
+          <QualifiedDC:rights xml:lang="dut">some rights</QualifiedDC:rights>
+          <QualifiedDC:identifier xml:lang="dut">some identifier</QualifiedDC:identifier>
+          <QualifiedDC:title xml:lang="dut">some title</QualifiedDC:title>
+          <QualifiedDC:title xml:lang="dut">some title</QualifiedDC:title>
+          <QualifiedDC:source xml:lang="dut">some source</QualifiedDC:source>
+        </DC:dc>
+      </xmlData>
+    </mdWrap>
+  </dmdSec>
+  <amdSec ID="AMD_TIF">
+    <techMD ID="AMD_TIF_0001">
+      <mdWrap MDTYPE="NISOIMG">
+        <xmlData>
+          <mix xmlns="http://www.loc.gov/mix/v10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd">
+            <BasicDigitalObjectInformation>
+              <ObjectIdentifier>
+                <objectIdentifierType>some type</objectIdentifierType>
+                <objectIdentifierValue>some value</objectIdentifierValue>
+              </ObjectIdentifier>
+              <fileSize>1</fileSize>
+              <FormatDesignation>
+                <formatName>image/tiff</formatName>
+                <formatVersion>6.0</formatVersion>
+              </FormatDesignation>
+              <byteOrder>little_endian</byteOrder>
+              <Compression>
+                <compressionScheme>Uncompressed</compressionScheme>
+              </Compression>
+              <Fixity>
+                <messageDigestAlgorithm>MD5</messageDigestAlgorithm>
+                <messageDigest>55163305A1EAA23AEEDB74A4BAAD7447</messageDigest>
+              </Fixity>
+            </BasicDigitalObjectInformation>
+            <BasicImageInformation>
+              <BasicImageCharacteristics>
+                <imageWidth>3186</imageWidth>
+                <imageHeight>4530</imageHeight>
+                <PhotometricInterpretation>
+                  <colorSpace>Uncalibrated</colorSpace>
+                </PhotometricInterpretation>
+              </BasicImageCharacteristics>
+            </BasicImageInformation>
+            <ImageCaptureMetadata>
+              <SourceInformation>
+                <SourceID>
+                  <sourceIDType>title</sourceIDType>
+                  <sourceIDValue>some value</sourceIDValue>
+                </SourceID>
+              </SourceInformation>
+              <GeneralCaptureInformation>
+                <dateTimeCreated>2014-08-19T10:21:02</dateTimeCreated>
+                <imageProducer>some producer</imageProducer>
+              </GeneralCaptureInformation>
+              <ScannerCapture>
+                <scannerManufacturer>some scanner manufacturer</scannerManufacturer>
+                <ScannerModel>
+                  <scannerModelName>some scanner model</scannerModelName>
+                </ScannerModel>
+                <ScanningSystemSoftware>
+                  <scanningSoftwareName>some scanning software</scanningSoftwareName>
+                </ScanningSystemSoftware>
+              </ScannerCapture>
+              <orientation>1</orientation>
+            </ImageCaptureMetadata>
+            <ImageAssessmentMetadata>
+              <SpatialMetrics>
+                <xSamplingFrequency>
+                  <numerator>300</numerator>
+                </xSamplingFrequency>
+                <ySamplingFrequency>
+                  <numerator>300</numerator>
+                </ySamplingFrequency>
+              </SpatialMetrics>
+              <ImageColorEncoding>
+                <bitsPerSample>
+                  <bitsPerSampleValue>8</bitsPerSampleValue>
+                  <bitsPerSampleUnit>integer</bitsPerSampleUnit>
+                </bitsPerSample>
+                <samplesPerPixel>3</samplesPerPixel>
+              </ImageColorEncoding>
+            </ImageAssessmentMetadata>
+            <extension>
+              <formatName>image/tiff</formatName>
+              <formatVersion>6.0</formatVersion>
+              <byteOrder>little_endian</byteOrder>
+              <Compression>Uncompressed</Compression>
+              <sourceType>
+              </sourceType>
+            </extension>
+          </mix>
+        </xmlData>
+      </mdWrap>
+    </techMD>
+    <techMD ID="AMD_TIF_0002">
+      <mdWrap MDTYPE="NISOIMG">
+        <xmlData>
+          <mix xmlns="http://www.loc.gov/mix/v10" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/mix/v10 http://www.loc.gov/standards/mix/mix10/mix10.xsd">
+            <BasicDigitalObjectInformation>
+              <ObjectIdentifier>
+                <objectIdentifierType>some type</objectIdentifierType>
+                <objectIdentifierValue>some value</objectIdentifierValue>
+              </ObjectIdentifier>
+              <fileSize>1</fileSize>
+              <FormatDesignation>
+                <formatName>image/tiff</formatName>
+                <formatVersion>6.0</formatVersion>
+              </FormatDesignation>
+              <byteOrder>little_endian</byteOrder>
+              <Compression>
+                <compressionScheme>Uncompressed</compressionScheme>
+              </Compression>
+              <Fixity>
+                <messageDigestAlgorithm>MD5</messageDigestAlgorithm>
+                <messageDigest>EF69185BBAAF2F443AC489630D06EC85</messageDigest>
+              </Fixity>
+            </BasicDigitalObjectInformation>
+                        <BasicImageInformation>
+              <BasicImageCharacteristics>
+                <imageWidth>3186</imageWidth>
+                <imageHeight>4530</imageHeight>
+                <PhotometricInterpretation>
+                  <colorSpace>Uncalibrated</colorSpace>
+                </PhotometricInterpretation>
+              </BasicImageCharacteristics>
+            </BasicImageInformation>
+            <ImageCaptureMetadata>
+              <SourceInformation>
+                <SourceID>
+                  <sourceIDType>title</sourceIDType>
+                  <sourceIDValue>some value</sourceIDValue>
+                </SourceID>
+              </SourceInformation>
+              <GeneralCaptureInformation>
+                <dateTimeCreated>2014-08-19T10:21:02</dateTimeCreated>
+                <imageProducer>some producer</imageProducer>
+              </GeneralCaptureInformation>
+              <ScannerCapture>
+                <scannerManufacturer>some scanner manufacturer</scannerManufacturer>
+                <ScannerModel>
+                  <scannerModelName>some scanner model</scannerModelName>
+                </ScannerModel>
+                <ScanningSystemSoftware>
+                  <scanningSoftwareName>some scanning software</scanningSoftwareName>
+                </ScanningSystemSoftware>
+              </ScannerCapture>
+              <orientation>1</orientation>
+            </ImageCaptureMetadata>
+            <ImageAssessmentMetadata>
+              <SpatialMetrics>
+                <xSamplingFrequency>
+                  <numerator>300</numerator>
+                </xSamplingFrequency>
+                <ySamplingFrequency>
+                  <numerator>300</numerator>
+                </ySamplingFrequency>
+              </SpatialMetrics>
+              <ImageColorEncoding>
+                <bitsPerSample>
+                  <bitsPerSampleValue>8</bitsPerSampleValue>
+                  <bitsPerSampleUnit>integer</bitsPerSampleUnit>
+                </bitsPerSample>
+                <samplesPerPixel>3</samplesPerPixel>
+              </ImageColorEncoding>
+            </ImageAssessmentMetadata>
+            <extension>
+              <formatName>image/tiff</formatName>
+              <formatVersion>6.0</formatVersion>
+              <byteOrder>little_endian</byteOrder>
+              <Compression>Uncompressed</Compression>
+              <sourceType>
+              </sourceType>
+            </extension>
+          </mix>
+        </xmlData>
+      </mdWrap>
+    </techMD>
+  </amdSec>
+  <fileSec>
+    <fileGrp ID="GRP_TIF" ADMID="AMD_TIF" USE="LONG TERM PRESERVATION IMAGES">
+      <file ID="GRP_TIF_0001" ADMID="AMD_TIF_0001" MIMETYPE="image/tiff">
+        <FLocat xlink:href="file:///./TIF/AVM_19441014_0001.tif" LOCTYPE="URL" />
+      </file>
+      <file ID="GRP_TIF_0002" ADMID="AMD_TIF_0002" MIMETYPE="image/tiff">
+        <FLocat xlink:href="file:///./TIF/AVM_19441014_0002.tif" LOCTYPE="URL" />
+      </file>
+    </fileGrp>
+    <fileGrp ID="GRP_JPG" USE="PRESENTATION IMAGES">
+      <file ID="GRP_JPG_0001" MIMETYPE="image/jpeg">
+        <FLocat xlink:href="file:///./JPG/AVM_19441014_0001.jpg" LOCTYPE="URL" />
+      </file>
+      <file ID="GRP_JPG_0002" MIMETYPE="image/jpeg">
+        <FLocat xlink:href="file:///./JPG/AVM_19441014_0002.jpg" LOCTYPE="URL" />
+      </file>
+    </fileGrp>
+    <fileGrp ID="GRP_ALTO" USE="OCR RESULTS">
+      <file ID="GRP_ALTO_0001" MIMETYPE="text/xml">
+        <FLocat xlink:href="file:///./Alto/AVM_19441014_0001.xml" LOCTYPE="URL" />
+      </file>
+      <file ID="GRP_ALTO_0002" MIMETYPE="text/xml">
+        <FLocat xlink:href="file:///./Alto/AVM_19441014_0002.xml" LOCTYPE="URL" />
+      </file>
+    </fileGrp>
+    <fileGrp ID="GRP_ISSUE_PDF" USE="COMPLETE PDF">
+      <file ID="GRP_CPDF_0001" MIMETYPE="application/pdf">
+        <FLocat xlink:href="file:///./AVM_19441014.pdf" LOCTYPE="URL" />
+      </file>
+    </fileGrp>
+  </fileSec>
+  <structMap>
+    <div DMDID="DC_METADATA" LABEL="AVM_19441014" TYPE="Document">
+      <div LABEL="Page_1" TYPE="Page">
+        <fptr FILEID="GRP_TIF_0001" />
+        <fptr FILEID="GRP_JPG_0001" />
+        <fptr FILEID="GRP_ALTO_0001" />
+      </div>
+      <div LABEL="Page_2" TYPE="Page">
+        <fptr FILEID="GRP_TIF_0002" />
+        <fptr FILEID="GRP_JPG_0002" />
+        <fptr FILEID="GRP_ALTO_0002" />
+      </div>
+    </div>
+  </structMap>
+</mets>


### PR DESCRIPTION
If MD5 checksums are provided in the original METS, include them in the init message so that they can be used later on to fill the new METS.